### PR TITLE
Added "arguments" feature to add-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
 # Add Host (add-host)
 
-A simples, very simple, script to add an host to your host file!
+A simple script to add an host to your /etc/hosts file!
 Just because i think that is boring to aways open an editor just to add an single line on this file.
 
-## How to use
-The inital idea just adds the phrase you pass to the script with the default localhost ip: ``127.0.0.1``.  
+## Installing
+``$ npm instal -g add-host``
 
-Install it: ``$ npm instal -g add-host``
+## Usage
+##### Basic usage:
+``add-host -a alias [-i, --ip] [-c, --comment] [-h, --help]``
 
-This: ``$ sudo add-host mybeaultifulsite.dev``  
+##### Example [1]: Add a host with default ip 127.0.0.1
+``add-host -a dummy.dev``
 
-Adds this: ``127.0.0.1 mybeaultifulsite.dev`` to your hosts file.
+##### Example [2]: Add a host setting all values
+``add-host -i 192.168.1.1 -a dummy.dev -c "This is a dummy host"``
+
+##### Example [3]: Getting some help
+``add-host -h, add-host --help``
+
+##### Available [options] are:
+- ``-i, --ip`` OPTIONAL, default: 127.0.0.1 (Set host ip/address)
+- ``-a, --alias`` (Set alias for host)
+- ``-c, --comment`` OPTIONAL (Set comment for added host)
+- ``-h, --help`` (See this beautyful description)
 
 **It's perfect!**
+
+## License
+Add-Host is developed under MIT license.
 
 ## Contributing
 Want to contribute? Great!

--- a/bin/add-host.js
+++ b/bin/add-host.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
 var addHost = require('../index.js');
-var newHost = process.argv[2];
 
-addHost(newHost);
+addHost(process.argv);

--- a/index.js
+++ b/index.js
@@ -1,20 +1,126 @@
 var isRoot = require('is-root');
 var fs = require('fs');
+var parsec = require('parsec');
 
-module.exports = function addHost(newHost) {
-  if(isRoot()) {
-    if(newHost) {
-      fs.appendFile('/etc/hosts', '\n127.0.0.1 ' + newHost + ' \n', function (err) {
-        if (err) throw err;
+/**
+ * Adds a single host to /etc/hosts file based on options array.
+ *
+ * Help can be found in: add-host -h
+ *
+ * @param  array arguments
+ * @return void
+ */
+module.exports = function addHost(arguments) {
+
+    // Parse arguments
+    args = parsec.parse(arguments)
+        .options(['i', 'ip'], { default : false } )
+        .options(['a', 'alias'], { default : false } )
+        .options(['c', 'comment'], { default : false } )
+        .options(['h', 'help'], { default : false } );
+
+    // Get necessary vars
+    var ip = args.ip;
+    var alias = args.alias;
+    var comment = args.comment;
+    var help = args.help;
+
+    // Check arguments
+    checkArgs(args);
+
+    // Adjust ip
+    ip = typeof ip === 'string' ? ip : '127.0.0.1';
+
+    // Adjust comment
+    comment = typeof comment === 'string' ? '# ' + comment + '\n' : '';
+
+    // Append new host to file
+    fs.appendFile('/etc/hosts', '\n' + comment + ip + ' \t' + alias + ' \n', function (err) {
+        if (err)
+            fireHelp("\n\tERROR: " + err);
+
         fs.readFile('/etc/hosts', function (err, data) {
-          if (err) throw err;
-          console.log(data.toString());
+            if (err)
+                fireHelp("\n\tERROR: " + err);
+
+            console.log(data.toString());
         });
-      });
-    } else {
-      console.log('Error! "add-host newhost.dev"');
-    }
-  } else {
-    console.warn('You have to use sudo or be a root user');
-  }
+    });
 }
+
+/**
+ * Check app arguments.
+ *
+ * @param  array arguments
+ * @return void
+ */
+checkArgs = function (args) {
+
+    // Get necessary vars
+    var ip = args.ip;
+    var alias = args.alias;
+    var comment = args.comment;
+    var help = args.help;
+
+    // Check for help
+    if (help)
+        fireHelp();
+
+    // Check for invalid options
+    if ( typeof args._ !== 'undefined' )
+        fireHelp("\n\tERROR: invalid option \"" + args._ + "\"");
+
+    // Check if alias is set, at least
+    if ( typeof alias !== 'string' )
+        fireHelp("\n\tERROR: Invalid value for option -a, --alias");
+
+    // Check if alias is set, at least
+    if ( typeof ip !== 'string' && ip === true )
+        fireHelp("\n\tERROR: Invalid value for option -i, --ip");
+
+    // Check if alias is set, at least
+    if ( typeof comment !== 'string' && comment === true )
+        fireHelp("\n\tERROR: Invalid value for option -c, --comment");
+
+    // Check if user is root
+    if ( ! isRoot())
+        fireHelp("\n\tERROR: You have to use sudo or be a root user");
+};
+
+/**
+ * Throws app help.
+ * It is possible to send a message to be shown.
+ *
+ * @param  string msg
+ * @return void
+ */
+fireHelp = function (msg) {
+
+    // Additional message
+    if (msg) {
+        console.log(msg);
+        console.log("\n\t---");
+    }
+
+    // Usage
+    console.log("\n\tUsage:");
+    console.log("\tadd-host -a alias [-i, --ip] [-c, --comment] [-h, --help]");
+
+    // Examples
+    console.log("\n\tExample [1]: Add a host setting all values");
+    console.log("\tadd-host -i 192.168.1.1 -a dummy.dev -c \"This is a dummy host\"");
+    console.log("\n\tExample [2]: Add a host with default ip 127.0.0.1");
+    console.log("\tadd-host -a dummy.dev");
+    console.log("\n\tExample [3]: Getting some help");
+    console.log("\tadd-host -h, add-host --help");
+
+    // Options
+    console.log("\n\tAvailable [options] are:");
+    console.log("\t-i, --ip [OPTIONAL, default: 127.0.0.1] (Set host ip/address)");
+    console.log("\t-a, --alias (Set alias for host)");
+    console.log("\t-c, --comment [OPTIONAL] (Set comment for added host)");
+    console.log("\t-h, --help (See this beautyful description)\n");
+
+    // Stop app
+    process.exit(-1);
+};

--- a/package.json
+++ b/package.json
@@ -1,19 +1,29 @@
 {
-  "name": "add-host",
-  "version": "0.1.0",
-  "description": "A simple script to add a new host to your hosts file.",
-  "main": "index.js",
-  "dependencies": {
-    "is-root": "^1.0.0"
-  },
-  "bin": {
-    "add-host" : "bin/add-host.js" 
-  },
-  "preferGlobal": "true",
-  "devDependencies": {},
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "Bruno Oliveira (bruno.oliveirati1@gmail.com)",
-  "license": "MIT"
+    "name": "add-host",
+    "version": "0.2.0",
+    "description": "A simple script to add a new host to your hosts file.",
+    "author": "Bruno Oliveira <bruno.oliveirati1@gmail.com>",
+    "contributors" : [{
+        "name" : "Leandro Mangini Antunes",
+        "email" : "leandrowkz@gmail.com"
+    }],
+    "bin": {
+      "add-host" : "bin/add-host.js"
+    },
+    "main": "index.js",
+    "dependencies": {
+        "is-root": "^1.0.0",
+        "parsec": "latest"
+    },
+    "preferGlobal": "true",
+    "devDependencies": {},
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "license": "MIT",
+    "keywords" : [
+        "add",
+        "host",
+        "hosts"
+    ]
 }


### PR DESCRIPTION
Now you have to send parameters to define your host. Available options are:
- -h, --help
- -i, --ip
- -a, --alias
- -c, --comment
